### PR TITLE
extract api route to dedicated controller

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,6 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use NovaCards\SystemInformationCard\SystemInformation;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,13 +12,4 @@ use NovaCards\SystemInformationCard\SystemInformation;
 | as many additional routes to this file as your card may require.
 |
 */
-
-Route::get('/stats', function (Request $request, SystemInformation $systemInformation) {
-    return response()->json([
-        'avg' => $systemInformation->avg(),
-        'mem' => $systemInformation->memory(),
-        'disk' => $systemInformation->disk(),
-        'systemTime' => $systemInformation->systemTime()->toIso8601ZuluString(),
-        'upTime' => $systemInformation->uptime()
-    ]);
-});
+Route::get('/stats', \NovaCards\SystemInformationCard\Http\Controllers\CardController::class . '@index');

--- a/src/Http/Controllers/CardController.php
+++ b/src/Http/Controllers/CardController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace NovaCards\SystemInformationCard\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use NovaCards\SystemInformationCard\SystemInformation;
+
+class CardController extends Controller
+{
+    public function index(Request $request, SystemInformation $systemInformation)
+    {
+        return response()->json([
+            'avg' => $systemInformation->avg(),
+            'mem' => $systemInformation->memory(),
+            'disk' => $systemInformation->disk(),
+            'systemTime' => $systemInformation->systemTime()->toIso8601ZuluString(),
+            'upTime' => $systemInformation->uptime()
+        ]);
+    }
+}


### PR DESCRIPTION
### Actual Problem

Using closured routes makes `php artisan route:cache` crash.

### Solution

Binding the `/stats` route to a Controller action, makes the application routes cachable again.
